### PR TITLE
[FIX] 캘린더 날짜 선택시 효과 및 날짜별 일정 개수 span 구현

### DIFF
--- a/app/src/main/java/com/example/miruni/HomepageFragment.kt
+++ b/app/src/main/java/com/example/miruni/HomepageFragment.kt
@@ -41,12 +41,12 @@ class HomepageFragment: Fragment() {
         lifecycleScope.launch {
             taskDB = ScheduleDatabase.getInstance(requireContext())!!
             if(taskDB.taskDao().getTask().isEmpty()) {
-                taskDB.taskDao().insert(Task(scheduleId = 0,startTime = "12:00", endTime ="14:00",title =  "[회계원리] 레포트 과제 (1)", status ="expected"))
-                taskDB.taskDao().insert(Task(scheduleId =0,startTime ="11:00", endTime ="15:30", title ="[자료구조] 강의 정리",  status ="fail"))
-                taskDB.taskDao().insert(Task(scheduleId =0,startTime ="12:00", endTime ="17:00", title ="[UI/UX] 와이어프레임 작성", status = "complete"))
-                taskDB.taskDao().insert(Task(scheduleId =0,startTime ="12:00", endTime ="15:30", title ="[회계원리] 레포트 과제 (1)", status = "expected"))
-                taskDB.taskDao().insert(Task(scheduleId =0,startTime ="12:00", endTime ="14:00", title ="[UI/UX] 와이어프레임 작성", status = "complete"))
-                taskDB.taskDao().insert(Task(scheduleId =0,startTime ="12:00", endTime ="14:00", title ="[자료구조] 강의 정리",  status ="expected"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime = "12:00", endTime ="14:00",title =  "[회계원리] 레포트 과제 (1)", status ="expected"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime ="11:00", endTime ="15:30", title ="[자료구조] 강의 정리",  status ="fail"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime ="12:00", endTime ="17:00", title ="[UI/UX] 와이어프레임 작성", status = "complete"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime ="12:00", endTime ="15:30", title ="[회계원리] 레포트 과제 (1)", status = "expected"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime ="12:00", endTime ="14:00", title ="[UI/UX] 와이어프레임 작성", status = "complete"))
+                taskDB.taskDao().insert(Task(scheduleId = 0, executeDay = "2025-08-08", startTime ="12:00", endTime ="14:00", title ="[자료구조] 강의 정리",  status ="expected"))
             }
             withContext(Dispatchers.Main) {
                 taskDatas.addAll(taskDB.taskDao().getTask())

--- a/app/src/main/java/com/example/miruni/MainActivity.kt
+++ b/app/src/main/java/com/example/miruni/MainActivity.kt
@@ -155,6 +155,7 @@ class MainActivity : AppCompatActivity() {
             Task(
                 1,
                 "title1",
+                "2025-07-04",
                 "14:00",
                 "16:00",
                 "예정"
@@ -164,6 +165,7 @@ class MainActivity : AppCompatActivity() {
             Task(
                 1,
                 "title2",
+                "2025-07-04",
                 "15:00",
                 "16:00",
                 "예정"
@@ -173,6 +175,37 @@ class MainActivity : AppCompatActivity() {
             Task(
                 1,
                 "title3",
+                "2025-07-04",
+                "16:00",
+                "17:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                1,
+                "title4",
+                "2025-07-09",
+                "16:00",
+                "17:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                1,
+                "title5",
+                "2025-07-09",
+                "16:00",
+                "17:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                1,
+                "title6",
+                "2025-07-09",
                 "16:00",
                 "17:00",
                 "예정"
@@ -182,6 +215,7 @@ class MainActivity : AppCompatActivity() {
             Task(
                 2,
                 "titleA",
+                "2025-07-09",
                 "14:00",
                 "16:00",
                 "예정"
@@ -191,11 +225,133 @@ class MainActivity : AppCompatActivity() {
             Task(
                 2,
                 "titleB",
+                "2025-07-09",
                 "14:00",
                 "16:00",
                 "예정"
             )
         )
+        scheduleDB.taskDao().insert(
+            Task(
+                2,
+                "titleC",
+                "2025-07-09",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㄱ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㄴ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㄷ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㄹ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅁ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅂ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅅ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅇ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅈ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅊ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+        scheduleDB.taskDao().insert(
+            Task(
+                3,
+                "titleㅋ",
+                "2025-07-18",
+                "14:00",
+                "16:00",
+                "예정"
+            )
+        )
+
 
         /** schedule 테이블 초기화 */
         if (schedules.isNotEmpty()) return
@@ -204,6 +360,7 @@ class MainActivity : AppCompatActivity() {
                 "토익 LC 공부하기",
                 " ",
                 "2025-07-04",
+                "2025-07-15",
                 "상"
             )
         )
@@ -211,11 +368,20 @@ class MainActivity : AppCompatActivity() {
             Schedule(
                 "토익 RC 공부하기",
                 " ",
-                "2025-07-05",
+                "2025-07-09",
+                "2025-07-21",
                 "상"
             )
         )
-
+        scheduleDB.scheduleDao().insert(
+            Schedule(
+                "토익 공부하기",
+                " ",
+                "2025-07-18",
+                "2025-07-29",
+                "상"
+            )
+        )
     }
 
     /**
@@ -332,7 +498,7 @@ class MainActivity : AppCompatActivity() {
             if (before(Calendar.getInstance())) add(Calendar.DATE, 1)
         }
 
-        val dummyTask = Task(-1, "랜덤 팝업", "00:00", "00:00", "random")
+        val dummyTask = Task(-1, "랜덤 팝업","2025-08-08", "00:00", "00:00", "random")
         AlarmHelper.setAlarm(context, calendar.timeInMillis, dummyTask, AlarmHelper.AlarmType.POPUP)
     }
 

--- a/app/src/main/java/com/example/miruni/data/Schedule.kt
+++ b/app/src/main/java/com/example/miruni/data/Schedule.kt
@@ -7,8 +7,9 @@ import androidx.room.PrimaryKey
 data class Schedule(
     var title: String, // 대주제 이름
     var comment: String, // 한 줄 설명
-    var date: String, // 마감 기한 yyyy-mm-dd
-    var priority: String // 우선 순위
+    var startDate: String, // 시작 기한(=수행날짜) yyyy-mm-dd
+    var endDate: String, // 종료 기한(=마감 날짜) yyyy-mm-dd
+    var priority: String // 우선 순위 - HIGH, MEDIUM, LOW
 ) {
     @PrimaryKey(autoGenerate = true) var id: Int = 0
 }

--- a/app/src/main/java/com/example/miruni/data/ScheduleDao.kt
+++ b/app/src/main/java/com/example/miruni/data/ScheduleDao.kt
@@ -21,18 +21,18 @@ interface ScheduleDao {
     /**
      * 단일 조회
      */
-    @Query("SELECT id, title, comment, date, priority FROM ScheduleTable WHERE id = :id")
+    @Query("SELECT id, title, comment, startDate, endDate, priority FROM ScheduleTable WHERE id = :id")
     fun getSchedule(id: Int): Schedule
 
     /**
      * 테이블 전체 조회
      */
-    @Query("SELECT id, title, comment, date, priority FROM ScheduleTable")
+    @Query("SELECT id, title, comment, startDate, endDate, priority FROM ScheduleTable")
     fun getSchedules(): List<Schedule>
 
     /**
      * 날짜별 Schedule 정리
      */
-    @Query("SELECT id, title, comment, date, priority FROM ScheduleTable WHERE date = :date")
+    @Query("SELECT id, title, comment, startDate, endDate, priority FROM ScheduleTable WHERE startDate < :date & :date < endDate")
     fun getScheduleByDate(date: String): List<Schedule>
 }

--- a/app/src/main/java/com/example/miruni/data/ScheduleDatabase.kt
+++ b/app/src/main/java/com/example/miruni/data/ScheduleDatabase.kt
@@ -20,7 +20,7 @@ abstract class ScheduleDatabase: RoomDatabase() {
                     instance = Room.databaseBuilder(
                         context.applicationContext,
                         ScheduleDatabase::class.java,
-                        "clothes-database"//다른 데이터 베이스랑 이름겹치면 꼬임
+                        "schedules-database"//다른 데이터 베이스랑 이름겹치면 꼬임
                     ).allowMainThreadQueries().build()
                 }
             }

--- a/app/src/main/java/com/example/miruni/data/Task.kt
+++ b/app/src/main/java/com/example/miruni/data/Task.kt
@@ -7,8 +7,9 @@ import androidx.room.PrimaryKey
 data class Task(
     var scheduleId: Int,
     var title: String,
-    var startTime: String,
-    var endTime: String,
+    var executeDay: String, // yyyy-MM-dd
+    var startTime: String, // hh:mm
+    var endTime: String, // hh:mm
     var status: String?
 ) {
     @PrimaryKey(autoGenerate = true) var id: Int = 0

--- a/app/src/main/java/com/example/miruni/data/TaskDao.kt
+++ b/app/src/main/java/com/example/miruni/data/TaskDao.kt
@@ -21,19 +21,28 @@ interface TaskDao {
     /**
      * 단일 조회
      */
-    @Query("SELECT id, scheduleId, title, startTime, endTime, status FROM TaskTable WHERE id = :id")
+    @Query("SELECT id, scheduleId, title, executeDay, startTime, endTime, status FROM TaskTable WHERE id = :id")
     fun getTask(id: Int): Task
 
     /**
      * 테이블 전체 조회
      */
-    @Query("SELECT id, scheduleId, title, startTime, endTime, status FROM TaskTable")
+    @Query("SELECT id, scheduleId, title, executeDay, startTime, endTime, status FROM TaskTable")
     fun getTasks(): List<Task>
 
-    @Query("SELECT id, scheduleId, title, startTime, endTime, status " +
+    /**
+     * Schedule Id로 Schedule을 나눈 Task 모두 조회
+     */
+    @Query("SELECT id, scheduleId, title, executeDay, startTime, endTime, status " +
             "FROM TaskTable " +
             "WHERE scheduleId = :scheduleId")
     fun getTasksByScheduleId(scheduleId: Int): List<Task>
+
+    /**
+     * Task 수행 날짜로 Task 조회
+     */
+    @Query("SELECT * FROM TaskTable WHERE executeDay = :executeDay")
+    fun getTasksByDay(executeDay: String): List<Task>
 
     @Query("SELECT * FROM TaskTable")
     suspend fun getTask(): List<Task>

--- a/app/src/main/java/com/example/miruni/ui/calendar/CalendarDecorator.kt
+++ b/app/src/main/java/com/example/miruni/ui/calendar/CalendarDecorator.kt
@@ -1,45 +1,38 @@
 package com.example.miruni.ui.calendar
 
-import android.content.Context
-import androidx.core.content.ContextCompat
-import com.example.miruni.R
+import android.text.style.ForegroundColorSpan
+import androidx.core.graphics.toColorInt
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import com.prolificinteractive.materialcalendarview.DayViewDecorator
 import com.prolificinteractive.materialcalendarview.DayViewFacade
 
-//class eventDecorator(private val context: Context, scheduleList: List<Schedule>): DayViewDecorator {
-//class eventDecorator(private val context: Context, scheduleList: List<String>): DayViewDecorator {
-//
-//    private val eventDates = HashSet<CalendarDay>()
-//
-//    init {
-//        scheduleList.forEach { schedule ->
-//            val date = CalendarDay.from(schedule.date[0], schedule.date[1], schedule.date[2])
-//            eventDates.add(date)
-//        }
-//    }
-//
-//    override fun shouldDecorate(day: CalendarDay?): Boolean {
-//        return eventDates.contains(day)
-//    }
-//
-//    override fun decorate(view: DayViewFacade?) {
-//        view?.addSpan(DotSpan(10F, ContextCompat.getColor(context, R.color.isSubmitted)))
-//    }
-//}
-
-class SelectionDecorator(
-    private val context: Context,
-    private val selectedDate: CalendarDay
-): DayViewDecorator {
-    override fun shouldDecorate(day: CalendarDay?): Boolean {
+/**
+ * 날짜 선택 Decorator
+ */
+class SelectionDecorator(private val selectedDate: CalendarDay) : DayViewDecorator {
+    override fun shouldDecorate(day: CalendarDay): Boolean {
         return day == selectedDate
     }
 
-    override fun decorate(view: DayViewFacade?) {
-        val drawable = ContextCompat.getDrawable(context, R.drawable.selector_circle)
-        drawable?.let{
-            view?.setBackgroundDrawable(it)
-        }
+    override fun decorate(view: DayViewFacade) {
+        view.addSpan(ForegroundColorSpan("#1AE019".toColorInt()))
+    }
+}
+
+/**
+ * 날짜별 Task 수에 따라 Custom Span을 적용
+ */
+class EventDecorator(
+    private val day: CalendarDay,
+    private val count: Int,
+    private val countTextSize: Float
+) : DayViewDecorator {
+
+    override fun shouldDecorate(day: CalendarDay): Boolean {
+        return this.day == day
+    }
+
+    override fun decorate(view: DayViewFacade) {
+        view.addSpan(DotCountSpan(count, countTextSize))
     }
 }

--- a/app/src/main/java/com/example/miruni/ui/calendar/DelayedRVAdapter.kt
+++ b/app/src/main/java/com/example/miruni/ui/calendar/DelayedRVAdapter.kt
@@ -8,6 +8,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.miruni.data.Schedule
 import com.example.miruni.databinding.ItemDelayedBinding
 
+/**
+ * 미룬 일정 RVAdapter
+ */
 class DelayedRVAdapter: RecyclerView.Adapter<DelayedRVAdapter.ViewHolder>() {
     private val delayedItems = ArrayList<Schedule>()
     lateinit var binding: ItemDelayedBinding
@@ -41,7 +44,7 @@ class DelayedRVAdapter: RecyclerView.Adapter<DelayedRVAdapter.ViewHolder>() {
 
         fun bind(schedule: Schedule) {
             binding.itemDelayedTitleTv.text = schedule.title
-            binding.itemDelayedDateTv.text = schedule.date
+            binding.itemDelayedDateTv.text = schedule.endDate
         }
     }
 }

--- a/app/src/main/java/com/example/miruni/ui/calendar/DotCountSpan.kt
+++ b/app/src/main/java/com/example/miruni/ui/calendar/DotCountSpan.kt
@@ -1,0 +1,61 @@
+package com.example.miruni.ui.calendar
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.text.style.LineBackgroundSpan
+import androidx.core.graphics.toColorInt
+
+/**
+ * 날짜별 일정 갯수 표시하는 Span
+ */
+class DotCountSpan(
+    private val count: Int,
+    private val countTextSize: Float
+): LineBackgroundSpan {
+
+    override fun drawBackground(
+        canvas: Canvas,
+        paint: Paint,
+        left: Int,
+        right: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        lineNumber: Int
+    ) {
+        if (count <= 0) return
+
+        val originalColor = paint.color
+        val originalTextSize = paint.textSize
+        val originalAlign = paint.textAlign
+
+        val centerX = (left + right) / 2f
+        val centerY = baseline + 24f
+        val radius = 20f
+
+        paint.color = getColorForCount(count)
+        canvas.drawCircle(centerX, centerY, radius, paint)
+
+        paint.color = Color.WHITE
+        paint.textSize = countTextSize
+        paint.textAlign = Paint.Align.CENTER
+        canvas.drawText("$count", centerX, centerY + countTextSize / 3, paint)
+
+        paint.color = originalColor
+        paint.textSize = originalTextSize
+        paint.textAlign = originalAlign
+    }
+
+    private fun getColorForCount(count: Int): Int {
+        return when (count) {
+            in 1..5 -> "#A7CAFB".toColorInt()
+            in 6..10 -> "#FFAA00".toColorInt()
+            in 11..15 -> "#FF5500".toColorInt()
+            else -> "#FF0000".toColorInt()
+        }
+    }
+}

--- a/app/src/main/java/com/example/miruni/ui/calendar/RegistrationScheduleFragment.kt
+++ b/app/src/main/java/com/example/miruni/ui/calendar/RegistrationScheduleFragment.kt
@@ -1,4 +1,4 @@
-package com.example.miruni
+package com.example.miruni.ui.calendar
 
 import android.app.DatePickerDialog
 import android.graphics.Color
@@ -16,13 +16,14 @@ import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.graphics.toColorInt
+import com.example.miruni.MainActivity
+import com.example.miruni.R
 import com.example.miruni.api.ApiService
 import com.example.miruni.api.RegistrationScheduleResponse
 import com.example.miruni.api.ScheduleToRegister
 import com.example.miruni.api.getRetrofit
 import com.example.miruni.databinding.FragmentRegistrationScheduleBinding
 import com.example.miruni.databinding.LayoutDropdownPriorityBinding
-import com.example.miruni.ui.calendar.CalendarFragment
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/app/src/main/java/com/example/miruni/ui/calendar/TaskOnDateRVAdapter.kt
+++ b/app/src/main/java/com/example/miruni/ui/calendar/TaskOnDateRVAdapter.kt
@@ -4,21 +4,24 @@ import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.example.miruni.data.Schedule
+import com.example.miruni.data.ScheduleDatabase
 import com.example.miruni.data.Task
 import com.example.miruni.databinding.ItemTaskBinding
 
 class TaskOnDateRVAdapter : RecyclerView.Adapter<TaskOnDateRVAdapter.ViewHolder>() {
-    private val taskItems = ArrayList<Pair<Schedule,Task>>()
+    private val tasks = ArrayList<Task>()
     lateinit var binding: ItemTaskBinding
+    private lateinit var scheduleDB: ScheduleDatabase
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
         binding = ItemTaskBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
+        scheduleDB = ScheduleDatabase.getInstance(viewGroup.context)!!
+
         return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(taskItems[position])
+        holder.bind(tasks[position])
 
         holder.apply {
             binding.itemTaskItemFrm.setOnClickListener{
@@ -27,29 +30,30 @@ class TaskOnDateRVAdapter : RecyclerView.Adapter<TaskOnDateRVAdapter.ViewHolder>
         }
     }
 
-    override fun getItemCount(): Int = taskItems.size
+    override fun getItemCount(): Int = tasks.size
 
     @SuppressLint("NotifyDataSetChanged")
-    fun addTask(taskItems: ArrayList<Pair<Schedule, Task>>) {
-        this.taskItems.clear()
-        this.taskItems.addAll(taskItems)
+    fun addTask(tasks: ArrayList<Task>) {
+        this.tasks.clear()
+        this.tasks.addAll(tasks)
 
         notifyDataSetChanged()
     }
 
     @SuppressLint("NotifyDataSetChanged")
     fun deleteAllTasks() {
-        this.taskItems.clear()
+        this.tasks.clear()
 
         notifyDataSetChanged()
     }
 
     inner class ViewHolder(private val binding: ItemTaskBinding): RecyclerView.ViewHolder(binding.root) {
-        fun bind(taskItem: Pair<Schedule, Task>) {
-            binding.itemScheduleTitleTv.text = taskItem.first.title
-            binding.itemTaskTitleTv.text = taskItem.second.title
-            binding.itemSchedulePriorityTv.text = taskItem.first.priority
-            binding.itemTaskTimeTv.text = String.format("${taskItem.second.startTime} - ${taskItem.second.endTime}")
+        fun bind(task: Task) {
+            val schedule = scheduleDB.scheduleDao().getSchedule(task.scheduleId)
+            binding.itemScheduleTitleTv.text = schedule.title
+            binding.itemTaskTitleTv.text = task.title
+            binding.itemSchedulePriorityTv.text = schedule.priority
+            binding.itemTaskTimeTv.text = String.format("${task.startTime} - ${task.endTime}")
         }
     }
 }

--- a/app/src/main/res/layout/fragment_registration_schedule.xml
+++ b/app/src/main/res/layout/fragment_registration_schedule.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".RegistrationScheduleFragment">
+    tools:context=".ui.calendar.RegistrationScheduleFragment">
 
     <!-- 일정 등록하기(기본) -->
     <include

--- a/app/src/main/res/layout/layout_calendar_calendar.xml
+++ b/app/src/main/res/layout/layout_calendar_calendar.xml
@@ -34,6 +34,7 @@
             android:layout_height="match_parent"
             android:background="@color/white"
             app:mcv_selectionMode="single"
+            app:mcv_selectionColor="@color/white"
             app:mcv_firstDayOfWeek="sunday"
             app:mcv_showOtherDates="all"
             app:mcv_weekDayTextAppearance="@style/CalendarViewWeekCustom"/>


### PR DESCRIPTION
## Description
Fixes #87 

캘린더 뷰의 날짜 타일을 클릭 시 날짜 텍스트의 색상만 #1AE019로 변환
캘린더 뷰의 날짜 타일 내부에 일정의 갯수를 표시하는, 일정 갯수의 급간에 따라 다른 색상을 적용하는 span을 구현
* 일정 갯수에 따른 span 색상 규정

| 일정의 갯수 |        색상        |
|-------------|----------------|
|     1~5개     |    #A7CAFB   |
|     6~10개   |    #FFAA00    |
|   11~15개   |    #FF5500     |
|   16개 이상  |    #FF0000     |

## Type
- [x] 새로운 기능
* 날짜 선택 시 날짜 텍스트 색상을 변경하는 기능 구현
* 각 날짜에 있는 세부 일정의 갯수와 그것을 감싸는 Span을 구현
* 커스텀 Span은 일정 갯수의 급간에 따라 색상이 변경
* 커스텀 Span은 내부에 일정 갯수가 출력
- [x] 리팩토링
* Task 테이블 수정 및 개념 정리
: Task 별 수행 날짜 및 시간이 따로 있는 관계로, Task에 executeDay: String 필드 추가. ("yyyy-MM-dd")
기존 startTime: String, endTime: String은 각각 Task(세부 일정)의 시작 시간, 종료 시간 -> 차후 포인트 지급 계산에 이용
* Schedule 테이블 개념 수정: 기존 date:String 필드를 수정하여, startDate: String, endDate: String으로, 각각 시작 날짜(=일정 수행 날짜), 종료 날짜(=마감 일자)를 의미하도록 함. 일정 등록 시 일정 수행 날짜를 따로 입력받는 건에 대해 대응.
- [x] 버그 수정
* DB 테이블의 수정으로 발생한 사이드 이펙트 수정: 더미 데이터 및 이를 활용하는 메서드들의 로직 재설정(ex. 날짜별 RV에 대한 RV adapter)
            
## Screenshots

https://github.com/user-attachments/assets/e5c45016-96c6-4ebf-815d-c798de7b19a8


## ETC
추후 일정을 받아오는 GET관련 API와 연결은 TODO 처리한 loadTasks에 구현할 예정